### PR TITLE
FIX compatibility with Laravel 6.8

### DIFF
--- a/src/Console/SearchableModelMakeCommand.php
+++ b/src/Console/SearchableModelMakeCommand.php
@@ -41,7 +41,7 @@ class SearchableModelMakeCommand extends ModelMakeCommand
 
         $options[] = [
             'search-rule',
-            's',
+            null,
             InputOption::VALUE_REQUIRED,
             'Specify the search rule for the model. It\'ll be created if doesn\'t exist.',
         ];


### PR DESCRIPTION
Remove -s option for searchable model generation to fix compatibility with laravel 6.8